### PR TITLE
Fix destination file's FOS possibly not be closed.

### DIFF
--- a/androidutils/src/main/java/com/uwetrottmann/androidutils/AndroidUtils.java
+++ b/androidutils/src/main/java/com/uwetrottmann/androidutils/AndroidUtils.java
@@ -149,8 +149,14 @@ public class AndroidUtils {
         try {
             inChannel.transferTo(0, inChannel.size(), outChannel);
         } finally {
-            in.close();
-            out.close();
+            try {
+                in.close();
+            } catch (IOException ignored) {
+            }
+            try {
+                out.close();
+            } catch (IOException ignored) {
+            }
         }
     }
 }


### PR DESCRIPTION
If in.close() throws, out.close() should still be called.
This will swallow those those IOExceptions, as they probably aren't helpful to callers.
Java 7 has Throwable.addSuppressed (and try-with-resources), too.